### PR TITLE
chore: minor readability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ A minimal version of the game should support:
 - players play pieces sequentially
 - the game identifies winning turns and ends at that point
 
+As a stretch goal, consider how you might adapt your code to support the following features:
+
+- Connect "n" (e.g. Connect 5, Connect 1000, etc)
+- Variable grid size (e.g. a 10 x 10 grid, a 1 x 100 grid)
+
 #### Top tips
 
 - Don't worry, we don't expect you to complete all of the tasks within the allotted time. We're much more interested to see how you approach and break down the problem.

--- a/apps/js/src/app.jsx
+++ b/apps/js/src/app.jsx
@@ -1,7 +1,19 @@
 import { Game } from "./game";
+import { Layout, GameHelp } from "./app.styles";
 
 export const App = () => (
-  <Game rowCount={6} columnCount={7} sequenceLength={4} />
+  <Layout>
+    <Game />
+    <GameHelp>
+      <h1>Connect 4</h1>
+      <h2>How to play</h2>
+      <p>
+        This is a two player game. Each player takes turns to enter a coloured
+        counter into the grid. The first player to connect 4 of their counters
+        in a horizontal, vertical or diagonal line is the winner!
+      </p>
+    </GameHelp>
+  </Layout>
 );
 
 export default App;

--- a/apps/js/src/app.styles.js
+++ b/apps/js/src/app.styles.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  padding: 20px;
+  gap: 50px;
+`;
+
+export const GameHelp = styled.aside`
+  width: 400px;
+`;

--- a/apps/js/src/game/game-state.js
+++ b/apps/js/src/game/game-state.js
@@ -1,8 +1,7 @@
-export const calculateMoveResult = () => {
+export const createNewGameState = () => {
   throw new Error("Not implemented");
 };
 
-export const createNewGameState = (config) => {
-  // TODO Create a state to store the state of the grid
+export const calculateMoveResult = () => {
   throw new Error("Not implemented");
 };

--- a/apps/js/src/game/game-state.spec.js
+++ b/apps/js/src/game/game-state.spec.js
@@ -1,18 +1,8 @@
 import { createNewGameState } from "./game-state";
 
 describe("game-state", () => {
-  it.each([
-    [6, 7],
-    [3, 4],
-    [100, 80],
-  ])(
-    "should create a game state with a %s rows and %s columns",
-    (rowCount, columnCount) => {
-      createNewGameState({
-        rowCount,
-        columnCount,
-        sequenceLength: 4,
-      });
-    }
-  );
+  it("should create an empty game with 6 rows and 7 columns", () => {
+    const result = createNewGameState();
+    throw new Error("Not implemented");
+  });
 });

--- a/apps/js/src/game/game.jsx
+++ b/apps/js/src/game/game.jsx
@@ -1,20 +1,18 @@
 import { GameHelp, Grid, GridCell, GridColumn, Layout } from "./game.styles";
 
-export const Game = ({ rowCount, columnCount, sequenceLength }) => {
-  const rows = [...Array(rowCount).keys()];
-  const columns = [...Array(columnCount).keys()];
-
-  const executeMove = (columnId) => {
-    throw new Error("Not implemented");
-  };
+export const Game = () => {
+  const rows = [...Array(6).keys()];
+  const columns = [...Array(7).keys()];
 
   return (
-    <Layout>
+    <div>
       <Grid>
         {columns.map((columnId) => (
           <GridColumn
             key={`col-${columnId}`}
-            onClick={() => executeMove(columnId)}
+            onClick={() => {
+              console.log("column clicked");
+            }}
           >
             {rows.map((rowId) => (
               <GridCell
@@ -25,20 +23,9 @@ export const Game = ({ rowCount, columnCount, sequenceLength }) => {
           </GridColumn>
         ))}
       </Grid>
-      <GameHelp>
-        <h1>Connect {sequenceLength}</h1>
-        <h2>How to play</h2>
-        <p>
-          This is a two player game. Each player takes turns to enter a coloured
-          counter into the grid. The first player to connect {sequenceLength} of
-          their counters in a horizontal, vertical or diagonal line is the
-          winner!
-        </p>
-        <h2>Current game</h2>
-        <p>Current player: ??</p>
-        <p>Winner: ??</p>
-        <button>Start new game</button>
-      </GameHelp>
-    </Layout>
+      <p>Current player: TODO</p>
+      <p>Winner: TODO</p>
+      <button>Start new game</button>
+    </div>
   );
 };

--- a/apps/js/src/game/game.styles.js
+++ b/apps/js/src/game/game.styles.js
@@ -1,13 +1,5 @@
 import styled from "styled-components";
 
-export const Layout = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  padding: 20px;
-  gap: 50px;
-`;
-
 export const Grid = styled.div`
   display: flex;
   width: fit-content;
@@ -22,7 +14,7 @@ export const GridColumn = styled.button`
   all: unset;
   cursor: pointer;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   border-radius: 20px;
   border: 2px solid transparent;
   padding: 10px 0;

--- a/apps/ts/src/app.styles.ts
+++ b/apps/ts/src/app.styles.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  padding: 20px;
+  gap: 50px;
+`;
+
+export const GameHelp = styled.aside`
+  width: 400px;
+`;

--- a/apps/ts/src/app.tsx
+++ b/apps/ts/src/app.tsx
@@ -1,7 +1,19 @@
+import { GameHelp, Layout } from "./app.styles";
 import { Game } from "./game";
 
 export const App = () => (
-  <Game rowCount={6} columnCount={7} sequenceLength={4} />
+  <Layout>
+    <Game />
+    <GameHelp>
+      <h1>Connect 4</h1>
+      <h2>How to play</h2>
+      <p>
+        This is a two player game. Each player takes turns to enter a coloured
+        counter into the grid. The first player to connect 4 of their counters
+        in a horizontal, vertical or diagonal line is the winner!
+      </p>
+    </GameHelp>
+  </Layout>
 );
 
 export default App;

--- a/apps/ts/src/game/game-state.spec.ts
+++ b/apps/ts/src/game/game-state.spec.ts
@@ -1,18 +1,8 @@
 import { createNewGameState } from "./game-state";
 
 describe("game-state", () => {
-  it.each([
-    [6, 7],
-    [3, 4],
-    [100, 80],
-  ])(
-    "should create a game state with a %s rows and %s columns",
-    (rowCount, columnCount) => {
-      createNewGameState({
-        rowCount,
-        columnCount,
-        sequenceLength: 4,
-      });
-    }
-  );
+  it("should create an empty game with 6 rows and 7 columns", () => {
+    const result = createNewGameState();
+    throw new Error("Not implemented");
+  });
 });

--- a/apps/ts/src/game/game-state.ts
+++ b/apps/ts/src/game/game-state.ts
@@ -1,10 +1,7 @@
-import { GameConfig } from "../types/game";
-
-export const calculateMoveResult = (): unknown => {
+export const createNewGameState = (): unknown => {
   throw new Error("Not implemented");
 };
 
-export const createNewGameState = (config: GameConfig): unknown => {
-  // TODO Create a state to store the state of the grid
+export const calculateMoveResult = (): unknown => {
   throw new Error("Not implemented");
 };

--- a/apps/ts/src/game/game.styles.ts
+++ b/apps/ts/src/game/game.styles.ts
@@ -1,14 +1,6 @@
 import styled from "styled-components";
 import { Counter } from "../types/game";
 
-export const Layout = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  padding: 20px;
-  gap: 50px;
-`;
-
 export const Grid = styled.div`
   display: flex;
   width: fit-content;
@@ -23,7 +15,7 @@ export const GridColumn = styled.button`
   all: unset;
   cursor: pointer;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   border-radius: 20px;
   border: 2px solid transparent;
   padding: 10px 0;
@@ -49,8 +41,4 @@ export const GridCell = styled.div<GridCellProps>`
   border-radius: 50%;
   background-color: ${({ counter }) =>
     counter ? counterColor[counter] : "white"};
-`;
-
-export const GameHelp = styled.div`
-  width: 400px;
 `;

--- a/apps/ts/src/game/game.tsx
+++ b/apps/ts/src/game/game.tsx
@@ -1,21 +1,18 @@
-import { GameConfig } from "../types/game";
-import { GameHelp, Grid, GridCell, GridColumn, Layout } from "./game.styles";
+import { Grid, GridCell, GridColumn } from "./game.styles";
 
-export const Game = ({ rowCount, columnCount, sequenceLength }: GameConfig) => {
-  const rows = [...Array(rowCount).keys()];
-  const columns = [...Array(columnCount).keys()];
-
-  const executeMove = (columnId: number): void => {
-    throw new Error("Not implemented");
-  };
+export const Game = () => {
+  const rows = [...Array(6).keys()];
+  const columns = [...Array(7).keys()];
 
   return (
-    <Layout>
+    <div>
       <Grid>
         {columns.map((columnId) => (
           <GridColumn
             key={`col-${columnId}`}
-            onClick={() => executeMove(columnId)}
+            onClick={() => {
+              console.log("column clicked");
+            }}
           >
             {rows.map((rowId) => (
               <GridCell
@@ -26,20 +23,9 @@ export const Game = ({ rowCount, columnCount, sequenceLength }: GameConfig) => {
           </GridColumn>
         ))}
       </Grid>
-      <GameHelp>
-        <h1>Connect {sequenceLength}</h1>
-        <h2>How to play</h2>
-        <p>
-          This is a two player game. Each player takes turns to enter a coloured
-          counter into the grid. The first player to connect {sequenceLength} of
-          their counters in a horizontal, vertical or diagonal line is the
-          winner!
-        </p>
-        <h2>Current game</h2>
-        <p>Current player: ??</p>
-        <p>Winner: ??</p>
-        <button>Start new game</button>
-      </GameHelp>
-    </Layout>
+      <p>Current player: TODO</p>
+      <p>Winner: TODO</p>
+      <button>Start new game</button>
+    </div>
   );
 };

--- a/apps/ts/src/types/game.ts
+++ b/apps/ts/src/types/game.ts
@@ -1,7 +1,1 @@
-export type GameConfig = {
-  columnCount: number;
-  rowCount: number;
-  sequenceLength: number;
-};
-
 export type Counter = "red" | "yellow";


### PR DESCRIPTION
Some small changes to the coding exercise based on the first trial run:

- Remove the grid props (`rowCount`, `columnCount` and `sequenceLength`) - I originally included these with the intention of prompting more senior engineers to anticipate how they could support something like Connect 5 (one of the stretch tasks in the Guardian exercise), but this threw off a more junior engineer. I've removed the props and mentioned Connect 5 in the README instead. This should hopefully make it less intimidating for juniors, whilst still accommodating more senior engineers
- Moved the game info from the `Game` component to the `App` component - This will reduce the amount of code in the `Game` component, hopefully making it easier to read/understand.
- Renamed the `game-state` functions to make them a bit easier to understand

I hope these minor changes will improve the interview experience whilst still ensuring that the current round is fair, with candidates still essentially completing the same task.

I have a separate branch with more major changes that we can implement after the current round is complete.